### PR TITLE
Removed insecure mysql_query call

### DIFF
--- a/odm/include/db.php
+++ b/odm/include/db.php
@@ -51,7 +51,6 @@
 
 	function storeData($id, $data) {
 		global $con;
-		$result = mysql_query("INSERT INTO gcm_data(id, data) VALUES($id, '$data')");
 		$stmt = $con->prepare("INSERT INTO gcm_data(id, data) VALUES(?, ?)");
 		$stmt->execute(array($id, $data));
 	}


### PR DESCRIPTION
storeData called mysql_query directly, passing $data to it without proper quoting. The two following lines did the same thing by using prepare/execute, which is much safer.

I've just removed the call as it seems to be unnecessary anyway and poses a security-risk, as the only call to storeData right now passes a POST-variable directly.

I did not test the change, but as the mysql_query call just seems to be a leftover of previous cleanup work of the code no harm should be done.
